### PR TITLE
Update connection.js

### DIFF
--- a/src/actions/connection.js
+++ b/src/actions/connection.js
@@ -28,7 +28,7 @@ export class RemoveConnectionAction extends Action {
         this.connection = connection;
     }
     undo() {
-        this.editor.connect(output, input);
+        this.editor.connect(this.connection.output, this.connection.input);
         this.connection = reassign(this.connection);
     }
     redo() {


### PR DESCRIPTION
Bug fix - "this.connections." part of expression missing twice. Issue occurred when node with at least one connection were deleted and then undo() were called. Node were undoed correctly, but connection were not.

P.S. I could not fix this issue for more than 7 hours but then, I finally found it :-)